### PR TITLE
feat: add custom domain support for GitHub Pages

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -18,7 +18,7 @@
             "browser": "src/main.ts",
             "polyfills": ["zone.js"],
             "tsConfig": "tsconfig.app.json",
-            "assets": ["src/favicon.ico", "src/assets"],
+            "assets": ["src/favicon.ico", "src/CNAME", "src/assets"],
             "styles": [
               "src/styles.css"
             ],

--- a/src/CNAME
+++ b/src/CNAME
@@ -1,0 +1,1 @@
+javaamazonas.com.br


### PR DESCRIPTION
Adds src/CNAME (javaamazonas.com.br) and includes it in the Angular build assets so it is copied into dist/java-amazonas/browser on every build and published by the Actions-based Pages deploy workflow.