### PR TITLE
ci: build and test on every PR to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build (production)
+        run: npm run build -- --configuration production
+
+      - name: Run unit tests
+        run: npm test -- --no-watch --no-progress --browsers=ChromeHeadless


### PR DESCRIPTION
Runs npm ci, a production build, and the Karma/Jasmine suite (headless Chrome) on every pull request. Gives PRs (Dependabot's included) a pass/fail signal before merge instead of only finding out a bump broke the build after it's on main.